### PR TITLE
Add VSCode settings generator and a check for pkg manager

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,1 @@
-{
-    "editor.formatOnPaste": true,
-    "editor.formatOnSave": true
-}
+{"editor.formatOnPaste":true,"editor.formatOnSave":true}

--- a/dist/gh-standards.js
+++ b/dist/gh-standards.js
@@ -65,6 +65,7 @@ var R = __importStar(require("ramda"));
 var standards_1 = require("./standards");
 var ERROR_NO_TYPES = 'At least one valid type is required.';
 // const ERROR_INVALID_TYPE = (type: string) => `Type ${type} is not supported.`;
+var packageManager = process.env.PATH ? process.env.PATH.toLowerCase().includes('yarn') ? 'yarn' : 'npm' : 'npm';
 function start() {
     commander_1.default.parse(process.argv);
     if (!commander_1.default.args.length) {
@@ -244,7 +245,7 @@ function createConcurrentScript(scripts, killOthersOnFail) {
     var k = killOthersOnFail ? ' --kill-others-on-fail' : '';
     var n = scripts.join(',');
     var c = colors.slice(0, scripts.length).join(',');
-    var s = scripts.map(function (s) { return "\"yarn run " + s + "\""; }).join(' ');
+    var s = scripts.map(function (s) { return "\"" + packageManager + " run " + s + "\""; }).join(' ');
     return "concurrently" + k + " -n \"" + n + "\" -c \"" + c + "\" " + s;
 }
 function writeScripts(standards) {
@@ -256,7 +257,7 @@ function writeScripts(standards) {
                     scripts = __assign({}, mergePackageDictionary(standards, 'scripts'), { lint: createConcurrentScript(getMainScripts('lint', standards)), format: createConcurrentScript(getMainScripts('format', standards)) });
                     precommitScripts = {
                         hooks: {
-                            'pre-commit': 'yarn run format && yarn run lint'
+                            'pre-commit': packageManager + " run format && " + packageManager + " run lint"
                         }
                     };
                     if (!(scripts && precommitScripts)) return [3 /*break*/, 2];

--- a/dist/gh-standards.js
+++ b/dist/gh-standards.js
@@ -110,6 +110,39 @@ function processStandards(standards) {
                     return [4 /*yield*/, writeScripts(standards)];
                 case 4:
                     _a.sent();
+                    return [4 /*yield*/, configureSettings()];
+                case 5:
+                    _a.sent();
+                    return [2 /*return*/];
+            }
+        });
+    });
+}
+function configureSettings() {
+    return __awaiter(this, void 0, void 0, function () {
+        var vsCodeSettingsPath, settings;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    vsCodeSettingsPath = path_1.default.join(process.cwd(), '.vscode/settings.json');
+                    settings = {};
+                    console.log('> Configuring workspace settings');
+                    if (!!fs_extra_1.default.existsSync('.vscode')) return [3 /*break*/, 2];
+                    return [4 /*yield*/, fs_extra_1.default.mkdir('.vscode')];
+                case 1:
+                    _a.sent();
+                    return [3 /*break*/, 3];
+                case 2:
+                    if (fs_extra_1.default.existsSync(vsCodeSettingsPath)) {
+                        settings = JSON.parse(fs_extra_1.default.readFileSync(vsCodeSettingsPath).toString());
+                    }
+                    _a.label = 3;
+                case 3:
+                    settings['editor.formatOnPaste'] = true;
+                    settings['editor.formatOnSave'] = true;
+                    return [4 /*yield*/, fs_extra_1.default.writeFile(vsCodeSettingsPath, JSON.stringify(settings))];
+                case 4:
+                    _a.sent();
                     return [2 /*return*/];
             }
         });
@@ -200,7 +233,11 @@ function copyTemplates(standards) {
     });
 }
 function getMainScripts(type, standards) {
-    return R.uniq(R.flatten(standards.map(function (s) { return R.flatten(s.rules.map(function (r) { return r.type === type && r.mainScript ? r.mainScript : ''; }).filter(Boolean)); })));
+    return R.uniq(R.flatten(standards.map(function (s) {
+        return R.flatten(s.rules
+            .map(function (r) { return (r.type === type && r.mainScript ? r.mainScript : ''); })
+            .filter(Boolean));
+    })));
 }
 var colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
 function createConcurrentScript(scripts, killOthersOnFail) {
@@ -242,19 +279,29 @@ function writeScripts(standards) {
 }
 function mergePackageDictionary(standards, field) {
     return standards
-        .map(function (s) { return s.rules.map(function (r) { return r.packageChanges ? r.packageChanges[field] : []; }).reduce(function (p, c) { return R.merge(p, c); }); })
+        .map(function (s) {
+        return s.rules
+            .map(function (r) { return (r.packageChanges ? r.packageChanges[field] : []); })
+            .reduce(function (p, c) { return R.merge(p, c); });
+    })
         .reduce(function (p, c) { return R.merge(p, c); });
 }
 function mergePackageList(standards, field) {
-    return R.uniq(standards.map(function (s) {
+    return R.uniq(standards
+        .map(function (s) {
         return s.rules
-            .map(function (r) { return r.packageChanges && r.packageChanges[field] ? r.packageChanges[field] : []; })
+            .map(function (r) {
+            return r.packageChanges && r.packageChanges[field]
+                ? r.packageChanges[field]
+                : [];
+        })
             .reduce(function (p, c) {
             if (p === void 0) { p = []; }
             if (c === void 0) { c = []; }
             return p.concat(c);
         });
-    }).reduce(function (p, c) {
+    })
+        .reduce(function (p, c) {
         if (p === void 0) { p = []; }
         if (c === void 0) { c = []; }
         return p.concat(c);

--- a/dist/standards.js
+++ b/dist/standards.js
@@ -48,7 +48,7 @@ exports.javaScript = {
             },
             mainScript: 'js:lint',
             templates: ['../templates/lint/js']
-        }),
+        })
     ]
 };
 exports.typeScript = {
@@ -77,7 +77,7 @@ exports.typeScript = {
             },
             mainScript: 'ts:lint',
             templates: ['../templates/lint/ts']
-        }),
+        })
     ]
 };
 exports.scss = {
@@ -106,12 +106,12 @@ exports.scss = {
             },
             mainScript: 'scss:lint',
             templates: ['../templates/lint/scss']
-        }),
+        })
     ]
 };
 exports.standards = [exports.javaScript, exports.typeScript, exports.scss];
 // export interface Scripts<
-//   LintScripts extends string, 
+//   LintScripts extends string,
 //   FormatScripts extends string
 // > {
 //   lint: { [key in LintScripts]: string; }

--- a/package-lock.json
+++ b/package-lock.json
@@ -892,9 +892,9 @@
       }
     },
     "prettier": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.3.tgz",
-      "integrity": "sha512-kn/GU6SMRYPxUakNXhpP0EedT/KmaPzr0H5lIsDogrykbaxOpOfAFfk5XA7DZrJyMAv1wlMV3CPcZruGXVVUZw==",
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.16.4.tgz",
+      "integrity": "sha512-ZzWuos7TI5CKUeQAtFd6Zhm2s6EpAD/ZLApIhsF9pRvRtM1RFo61dM/4MSRUA0SuLugA/zgrZD8m0BaY46Og7g==",
       "dev": true
     },
     "pseudomap": {
@@ -1141,9 +1141,9 @@
       }
     },
     "tslint-config-prettier": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.17.0.tgz",
-      "integrity": "sha512-NKWNkThwqE4Snn4Cm6SZB7lV5RMDDFsBwz6fWUkTxOKGjMx8ycOHnjIbhn7dZd5XmssW3CwqUjlANR6EhP9YQw==",
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/tslint-config-prettier/-/tslint-config-prettier-1.18.0.tgz",
+      "integrity": "sha512-xPw9PgNPLG3iKRxmK7DWr+Ea/SzrvfHtjFt5LBl61gk2UBG/DB9kCXRjv+xyIU1rUtnayLeMUVJBcMX8Z17nDg==",
       "dev": true
     },
     "tslint-consistent-codestyle": {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build": "tsc -p ./",
     "ts:format": "prettier --write src/**/*.ts src/**/*.tsx",
     "ts:lint": "tslint --project ./",
-    "lint": "concurrently -n \"ts:lint\" -c \"red\" \"npm run ts:lint\"",
-    "format": "concurrently -n \"ts:format\" -c \"red\" \"npm run ts:format\""
+    "lint": "concurrently -n \"ts:lint\" -c \"red\" \"yarn run ts:lint\"",
+    "format": "concurrently -n \"ts:format\" -c \"red\" \"yarn run ts:format\""
   },
   "dependencies": {
     "@types/fs-extra": "^5.0.4",
@@ -40,13 +40,13 @@
     "@geekhive/tslint-config-standard": "^1.0.0",
     "concurrently": "^4.1.0",
     "husky": "^1.3.1",
-    "prettier": "^1.16.3",
+    "prettier": "^1.16.4",
     "tslint": "^5.12.1",
     "typescript": "^3.3.1"
   },
   "husky": {
     "hooks": {
-      "pre-commit": "npm run format && npm run lint"
+      "pre-commit": "yarn run format && yarn run lint"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build": "tsc -p ./",
     "ts:format": "prettier --write src/**/*.ts src/**/*.tsx",
     "ts:lint": "tslint --project ./",
-    "lint": "concurrently -n \"ts:lint\" -c \"red\" \"yarn run ts:lint\"",
-    "format": "concurrently -n \"ts:format\" -c \"red\" \"yarn run ts:format\""
+    "lint": "concurrently -n \"ts:lint\" -c \"red\" \"npm run ts:lint\"",
+    "format": "concurrently -n \"ts:format\" -c \"red\" \"npm run ts:format\""
   },
   "dependencies": {
     "@types/fs-extra": "^5.0.4",
@@ -46,7 +46,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "yarn run format && yarn run lint"
+      "pre-commit": "npm run format && npm run lint"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,13 @@
     "name": "Justin Firth",
     "email": "jfirth@geekhive.com"
   },
+  "contributors": [
+    {
+      "name": "Max Swartwout",
+      "email": "mkswartwout@gmail.com",
+      "url": "https://github.com/maxswa"
+    }
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/GeekHive/gh-cli"

--- a/src/gh-standards.ts
+++ b/src/gh-standards.ts
@@ -9,7 +9,11 @@ import { standards, Standard, PackageChanges, RuleType } from './standards';
 
 const ERROR_NO_TYPES = 'At least one valid type is required.';
 // const ERROR_INVALID_TYPE = (type: string) => `Type ${type} is not supported.`;
-const packageManager = process.env.PATH ? process.env.PATH.toLowerCase().includes('yarn') ? 'yarn' : 'npm' : 'npm';
+const packageManager = process.env.PATH
+  ? process.env.PATH.toLowerCase().includes('yarn')
+    ? 'yarn'
+    : 'npm'
+  : 'npm';
 
 function start() {
   program.parse(process.argv);

--- a/src/gh-standards.ts
+++ b/src/gh-standards.ts
@@ -9,6 +9,7 @@ import { standards, Standard, PackageChanges, RuleType } from './standards';
 
 const ERROR_NO_TYPES = 'At least one valid type is required.';
 // const ERROR_INVALID_TYPE = (type: string) => `Type ${type} is not supported.`;
+const packageManager = process.env.PATH ? process.env.PATH.toLowerCase().includes('yarn') ? 'yarn' : 'npm' : 'npm';
 
 function start() {
   program.parse(process.argv);
@@ -123,7 +124,7 @@ function createConcurrentScript(scripts: string[], killOthersOnFail?: boolean) {
   const k = killOthersOnFail ? ' --kill-others-on-fail' : '';
   const n = scripts.join(',');
   const c = colors.slice(0, scripts.length).join(',');
-  const s = scripts.map(s => `\"yarn run ${s}\"`).join(' ');
+  const s = scripts.map(s => `\"${packageManager} run ${s}\"`).join(' ');
   return `concurrently${k} -n \"${n}\" -c \"${c}\" ${s}`;
 }
 
@@ -136,7 +137,7 @@ async function writeScripts(standards: Standard[]) {
 
   const precommitScripts = {
     hooks: {
-      'pre-commit': 'yarn run format && yarn run lint'
+      'pre-commit': `${packageManager} run format && ${packageManager} run lint`
     }
   };
 

--- a/src/gh-standards.ts
+++ b/src/gh-standards.ts
@@ -38,6 +38,23 @@ async function processStandards(standards: Standard[]) {
   await installDevDependencies(standards);
   await copyTemplates(standards);
   await writeScripts(standards);
+  await configureSettings();
+}
+
+async function configureSettings() {
+  const vsCodeSettingsPath = path.join(process.cwd(), '.vscode/settings.json');
+  let settings: { [key: string]: string | boolean | number | null } = {};
+  console.log('> Configuring workspace settings');
+
+  if (!fs.existsSync('.vscode')) {
+    await fs.mkdir('.vscode');
+  } else if (fs.existsSync(vsCodeSettingsPath)) {
+    settings = JSON.parse(fs.readFileSync(vsCodeSettingsPath).toString());
+  }
+
+  settings['editor.formatOnPaste'] = true;
+  settings['editor.formatOnSave'] = true;
+  await fs.writeFile(vsCodeSettingsPath, JSON.stringify(settings));
 }
 
 async function installDependencies(standards: Standard[]) {


### PR DESCRIPTION
The CLI will now generate a `settings.json` file inside of the `.vscode` directory, creating either if non-existent. A check on the PATH was also added to see which package manager is installed. (If yarn is installed it will be used, otherwise npm)