### PR TITLE
Add accessibility tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # gh-cli
 
-A tool for easily installing front end language lint and formatting standards to projects.
+A tool for easily installing front end language lint and formatting standards and accessibility tools  to projects.
 
 ## Commands
 
-| Command                   | Description                               |
-| ------------------------- | ----------------------------------------- |
-| `standards [keywords...]` | Add standards for given standard keywords |
+| Command                   | Alias      | Description                               |
+| ------------------------- | ---------- | ----------------------------------------- |
+| `standards [keywords...]` | N/A        | Add standards for given standard keywords |
+| `accessibility [keywords...]` | `a11y [keywords...]` | Add accessibility tools for given accessibility tool keywords. If no keywords are provided, all supported tools are installed. |
 
 ## Standards
 
@@ -16,16 +17,28 @@ A tool for easily installing front end language lint and formatting standards to
 | TypeScript | `ts`    | [@geekhive/tslint-config-standard][@geekhive/tslint-config-standard]       | [TSLint][tslint]       | [Prettier][prettier] |
 | SCSS       | `scss`  | [@geekhive/stylelint-config-standard][@geekhive/stylelint-config-standard] | [stylelint][stylelint] | [Prettier][prettier] |
 
+## Accessibility
+
+| Accessibility   | Keyword | Accessibility Tool  |
+| --------------- | ------- | ------------------- |
+| aXe | `axe`    | [axe-cli][axe]       |
+| pa11y | `pa11y`    | [pa11y][pa11y]       |
+| lighthouse       | `lighthouse`  | [lighthouse][lighthouse] |
+
+
 ## Usage
 
-Run with [`npx`][npx]:
+### Run with [`npx`][npx]:
 
 ```sh
 # Run the CLI tool, installing JavaScript, TypeScript, and SCSS standards
 npx @geekhive/gh-cli standards js ts scss
+
+# Run the CLI tool, installing axe-cli, pa11y, and lighthouse accessibility tools
+npx @geekhive/gh-cli accessibility axe pa11y lighthouse
 ```
 
-Install the CLI tool globally and use:
+### Install the CLI tool globally:
 
 ```sh
 # Install globally with npm
@@ -33,9 +46,30 @@ npm install -g @geekhive/gh-cli
 
 # Install globally with yarn
 yarn add -g @geekhive/gh-cli
+```
 
+### Run CLI tool after global installation:
+
+#### Standards
+
+```sh
 # Run the CLI tool, installing JavaScript, TypeScript, and SCSS standards
 gh standards js ts scss
+```
+
+#### Accessibility
+
+Use `accessibility` or `a11y` command
+
+```sh
+# Run the CLI tool, installing support for pa11y
+gh accessibility pa11y 
+
+# Run the CLI tool, installing support for pa11y and lighthouse
+gh a11y pa11y lighthouse
+
+# Run the CLI tool, installing install support for all supported accessibility tools
+gh a11y
 ```
 
 ## Development
@@ -60,10 +94,22 @@ Execute the CLI tool:
 node dist/gh.js standards js ts scss
 ```
 
+Or:
+
+```sh
+node dist/gh.js accessibility axe pa11y lighthouse
+```
+
 Debug the CLI tool:
 
 ```sh
 node --inspect-brk dist/gh.js standards js ts scss
+```
+
+Or:
+
+```sh
+node --inspect-brk dist/gh.js accessibility axe pa11y lighthouse
 ```
 
 [npx]: https://www.npmjs.com/package/npx
@@ -74,3 +120,6 @@ node --inspect-brk dist/gh.js standards js ts scss
 [stylelint]: https://stylelint.io
 [@geekhive/stylelint-config-standard]: https://github.com/GeekHive/stylelint-config-standard
 [prettier]: https://prettier.io
+[axe]: https://github.com/dequelabs/axe-cli
+[pa11y]: https://github.com/pa11y/pa11y
+[lighthouse]: https://github.com/GoogleChrome/lighthouse#readme

--- a/dist/gh-accessibility.js
+++ b/dist/gh-accessibility.js
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+"use strict";
+var __assign = (this && this.__assign) || function () {
+    __assign = Object.assign || function(t) {
+        for (var s, i = 1, n = arguments.length; i < n; i++) {
+            s = arguments[i];
+            for (var p in s) if (Object.prototype.hasOwnProperty.call(s, p))
+                t[p] = s[p];
+        }
+        return t;
+    };
+    return __assign.apply(this, arguments);
+};
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var commander_1 = __importDefault(require("commander"));
+var fs_extra_1 = __importDefault(require("fs-extra"));
+var install_packages_1 = __importDefault(require("install-packages"));
+var path_1 = __importDefault(require("path"));
+var ramda_1 = __importDefault(require("ramda"));
+var standards_1 = require("./standards");
+var command = 'npm';
+function start() {
+    commander_1.default.parse(process.argv);
+    if (!commander_1.default.args.length) {
+        // Add all accessibility tools if list of arguments is omitted
+        processTypes(['axe', 'pa11y', 'lighthouse']);
+    }
+    else {
+        processTypes(commander_1.default.args);
+    }
+}
+function processTypes(types) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, install_packages_1.default.determinePackageManager(process.cwd())];
+                case 1:
+                    command = _a.sent();
+                    return [4 /*yield*/, processStandards(getSelectedStandards(types))];
+                case 2:
+                    _a.sent();
+                    return [2 /*return*/];
+            }
+        });
+    });
+}
+function getSelectedStandards(types) {
+    return standards_1.accessibilities.filter(function (standard) {
+        return types
+            // string[] -> boolean[] - whether any keyword of this standard matched the current type
+            .map(function (type) { return standard.keywords.reduce(function (p, c) { return p || c === type; }, false); })
+            // boolean[] -> boolean - whether this standard matched any type
+            .reduce(function (p, c) { return p || c; }, false);
+    });
+}
+function processStandards(standards) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, installDependencies(standards)];
+                case 1:
+                    _a.sent();
+                    return [4 /*yield*/, installDevDependencies(standards)];
+                case 2:
+                    _a.sent();
+                    return [4 /*yield*/, copyTemplates(standards)];
+                case 3:
+                    _a.sent();
+                    return [4 /*yield*/, writeScripts(standards)];
+                case 4:
+                    _a.sent();
+                    return [2 /*return*/];
+            }
+        });
+    });
+}
+function installDependencies(standards) {
+    return __awaiter(this, void 0, void 0, function () {
+        var dependencies, e_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    dependencies = mergePackageList(standards, 'dependencies');
+                    if (!dependencies.length) return [3 /*break*/, 5];
+                    console.log('> Installing dependencies:', dependencies.join(', '));
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, 3, , 4]);
+                    return [4 /*yield*/, install_packages_1.default({ packages: dependencies })];
+                case 2:
+                    _a.sent();
+                    return [3 /*break*/, 4];
+                case 3:
+                    e_1 = _a.sent();
+                    console.error(e_1);
+                    return [3 /*break*/, 4];
+                case 4: return [3 /*break*/, 6];
+                case 5:
+                    console.warn('> No dependencies provided');
+                    _a.label = 6;
+                case 6: return [2 /*return*/];
+            }
+        });
+    });
+}
+function installDevDependencies(standards) {
+    return __awaiter(this, void 0, void 0, function () {
+        var devDependencies, e_2;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    devDependencies = mergePackageList(standards, 'devDependencies');
+                    devDependencies.push('concurrently');
+                    devDependencies.push('husky');
+                    if (!devDependencies.length) return [3 /*break*/, 5];
+                    console.log('> Installing devDependencies:', devDependencies.join(', '));
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, 3, , 4]);
+                    return [4 /*yield*/, install_packages_1.default({ packages: devDependencies, saveDev: true })];
+                case 2:
+                    _a.sent();
+                    return [3 /*break*/, 4];
+                case 3:
+                    e_2 = _a.sent();
+                    console.error(e_2);
+                    return [3 /*break*/, 4];
+                case 4: return [3 /*break*/, 6];
+                case 5:
+                    console.warn('> No devDependencies provided');
+                    _a.label = 6;
+                case 6: return [2 /*return*/];
+            }
+        });
+    });
+}
+function copyTemplates(standards) {
+    return __awaiter(this, void 0, void 0, function () {
+        var templates;
+        var _this = this;
+        return __generator(this, function (_a) {
+            templates = mergeTemplates(standards);
+            if (templates.length) {
+                console.log('> Installing templates: ', templates.join(', '));
+                templates.forEach(function (template) { return __awaiter(_this, void 0, void 0, function () {
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, fs_extra_1.default.copy(path_1.default.join(path_1.default.dirname(require.resolve('./gh')), template), process.cwd(), { overwrite: true })];
+                            case 1: return [2 /*return*/, _a.sent()];
+                        }
+                    });
+                }); });
+            }
+            else {
+                console.warn('> No templates provided');
+            }
+            return [2 /*return*/];
+        });
+    });
+}
+function getMainScripts(type, standards) {
+    return ramda_1.default.uniq(ramda_1.default.flatten(standards.map(function (s) {
+        return ramda_1.default.flatten(s.rules
+            .map(function (r) { return (r.type === type && r.mainScript ? r.mainScript : ''); })
+            .filter(Boolean));
+    })));
+}
+var colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
+function createConcurrentScript(scripts, killOthersOnFail) {
+    var k = killOthersOnFail ? ' --kill-others-on-fail' : '';
+    var n = scripts.join(',');
+    var c = colors.slice(0, scripts.length).join(',');
+    var s = scripts.map(function (s) { return "\"" + command + " run " + s + "\""; }).join(' ');
+    return "concurrently" + k + " -n \"" + n + "\" -c \"" + c + "\" " + s;
+}
+function writeScripts(standards) {
+    return __awaiter(this, void 0, void 0, function () {
+        var scripts, precommitScripts, pkgJsonPath, pkg;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    scripts = __assign({}, mergePackageDictionary(standards, 'scripts'), { a11y: createConcurrentScript(getMainScripts('accessibility', standards)) });
+                    precommitScripts = {
+                        hooks: {
+                            'pre-commit': command + " run format && " + command + " run lint"
+                        }
+                    };
+                    console.log('> Writing scripts to package.json:', Object.keys(scripts).join(', '));
+                    pkgJsonPath = path_1.default.join(process.cwd(), 'package.json');
+                    pkg = JSON.parse(fs_extra_1.default.readFileSync(pkgJsonPath).toString());
+                    pkg.scripts = __assign({}, (pkg.scripts || {}), scripts);
+                    pkg.husky = __assign({}, (pkg.husky || {}), precommitScripts);
+                    return [4 /*yield*/, fs_extra_1.default.writeFile(pkgJsonPath, JSON.stringify(pkg, undefined, 2))];
+                case 1:
+                    _a.sent();
+                    return [2 /*return*/];
+            }
+        });
+    });
+}
+function mergePackageDictionary(standards, field) {
+    return standards
+        .map(function (s) {
+        return s.rules
+            .map(function (r) { return (r.packageChanges ? r.packageChanges[field] : []); })
+            .reduce(function (p, c) { return ramda_1.default.merge(p, c); });
+    })
+        .reduce(function (p, c) { return ramda_1.default.merge(p, c); });
+}
+function mergePackageList(standards, field) {
+    return ramda_1.default.uniq(standards
+        .map(function (s) {
+        return s.rules
+            .map(function (r) {
+            return r.packageChanges && r.packageChanges[field]
+                ? r.packageChanges[field]
+                : [];
+        })
+            .reduce(function (p, c) {
+            if (p === void 0) { p = []; }
+            if (c === void 0) { c = []; }
+            return p.concat(c);
+        });
+    })
+        .reduce(function (p, c) {
+        if (p === void 0) { p = []; }
+        if (c === void 0) { c = []; }
+        return p.concat(c);
+    }) || []);
+}
+function mergeTemplates(standards) {
+    return ramda_1.default.uniq(ramda_1.default.flatten(standards.map(function (s) { return ramda_1.default.flatten(s.rules.map(function (r) { return r.templates || []; })); })));
+}
+start();

--- a/dist/gh-accessibility.js
+++ b/dist/gh-accessibility.js
@@ -89,7 +89,7 @@ function processTypes(types) {
 }
 function writeScripts(selectedStandards) {
     return __awaiter(this, void 0, void 0, function () {
-        var pkgJsonPath, pkg, currentScripts, allMainScripts, scripts;
+        var pkgJsonPath, pkg, currentScripts, allMainScripts, allUniqueScripts, scripts;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
@@ -97,7 +97,8 @@ function writeScripts(selectedStandards) {
                     pkg = JSON.parse(fs_extra_1.default.readFileSync(pkgJsonPath).toString());
                     currentScripts = utility_1.checkConcurrentScript(pkg, 'a11y', standards_1.accessibilities);
                     allMainScripts = utility_1.getMainScripts('a11y', selectedStandards).concat(currentScripts);
-                    scripts = __assign({}, utility_1.mergePackageDictionary(selectedStandards, 'scripts'), { a11y: utility_1.createConcurrentScript(command, allMainScripts) });
+                    allUniqueScripts = allMainScripts.filter(function (script, index) { return allMainScripts.indexOf(script) === index; });
+                    scripts = __assign({}, utility_1.mergePackageDictionary(selectedStandards, 'scripts'), { a11y: utility_1.createConcurrentScript(command, allUniqueScripts) });
                     console.log('> Writing scripts to package.json:', Object.keys(scripts).join(', '));
                     pkg.scripts = __assign({}, (pkg.scripts || {}), scripts);
                     return [4 /*yield*/, fs_extra_1.default.writeFile(pkgJsonPath, JSON.stringify(pkg, undefined, 2))];

--- a/dist/gh-accessibility.js
+++ b/dist/gh-accessibility.js
@@ -61,7 +61,12 @@ function start() {
     commander_1.default.parse(process.argv);
     if (!commander_1.default.args.length) {
         // Add all accessibility tools if list of arguments is omitted
-        processTypes(['axe', 'pa11y', 'lighthouse']);
+        var pkgJsonPath = path_1.default.join(process.cwd(), 'package.json');
+        var pkg = JSON.parse(fs_extra_1.default.readFileSync(pkgJsonPath).toString());
+        var allAccessibilities = ['axe', 'pa11y', 'lighthouse'];
+        var currentScripts_1 = utility_1.checkConcurrentScript(pkg, 'a11y', standards_1.accessibilities);
+        var allTypes = allAccessibilities.filter(function (type) { return currentScripts_1.indexOf("a11y:" + type) === -1; });
+        processTypes(allTypes);
     }
     else {
         processTypes(commander_1.default.args);
@@ -82,16 +87,18 @@ function processTypes(types) {
         });
     });
 }
-function writeScripts(accessibilities) {
+function writeScripts(selectedStandards) {
     return __awaiter(this, void 0, void 0, function () {
-        var scripts, pkgJsonPath, pkg;
+        var pkgJsonPath, pkg, currentScripts, allMainScripts, scripts;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    scripts = __assign({}, utility_1.mergePackageDictionary(accessibilities, 'scripts'), { a11y: utility_1.createConcurrentScript(command, utility_1.getMainScripts('accessibility', accessibilities)) });
-                    console.log('> Writing scripts to package.json:', Object.keys(scripts).join(', '));
                     pkgJsonPath = path_1.default.join(process.cwd(), 'package.json');
                     pkg = JSON.parse(fs_extra_1.default.readFileSync(pkgJsonPath).toString());
+                    currentScripts = utility_1.checkConcurrentScript(pkg, 'a11y', standards_1.accessibilities);
+                    allMainScripts = utility_1.getMainScripts('a11y', selectedStandards).concat(currentScripts);
+                    scripts = __assign({}, utility_1.mergePackageDictionary(selectedStandards, 'scripts'), { a11y: utility_1.createConcurrentScript(command, allMainScripts) });
+                    console.log('> Writing scripts to package.json:', Object.keys(scripts).join(', '));
                     pkg.scripts = __assign({}, (pkg.scripts || {}), scripts);
                     return [4 /*yield*/, fs_extra_1.default.writeFile(pkgJsonPath, JSON.stringify(pkg, undefined, 2))];
                 case 1:

--- a/dist/gh-accessibility.js
+++ b/dist/gh-accessibility.js
@@ -54,8 +54,8 @@ var commander_1 = __importDefault(require("commander"));
 var fs_extra_1 = __importDefault(require("fs-extra"));
 var install_packages_1 = __importDefault(require("install-packages"));
 var path_1 = __importDefault(require("path"));
-var ramda_1 = __importDefault(require("ramda"));
 var standards_1 = require("./standards");
+var utility_1 = require("./utility");
 var command = 'npm';
 function start() {
     commander_1.default.parse(process.argv);
@@ -74,7 +74,7 @@ function processTypes(types) {
                 case 0: return [4 /*yield*/, install_packages_1.default.determinePackageManager(process.cwd())];
                 case 1:
                     command = _a.sent();
-                    return [4 /*yield*/, processStandards(getSelectedStandards(types))];
+                    return [4 /*yield*/, utility_1.processStandards(utility_1.getSelectedStandards(standards_1.accessibilities, types), writeScripts)];
                 case 2:
                     _a.sent();
                     return [2 /*return*/];
@@ -82,152 +82,17 @@ function processTypes(types) {
         });
     });
 }
-function getSelectedStandards(types) {
-    return standards_1.accessibilities.filter(function (standard) {
-        return types
-            // string[] -> boolean[] - whether any keyword of this standard matched the current type
-            .map(function (type) { return standard.keywords.reduce(function (p, c) { return p || c === type; }, false); })
-            // boolean[] -> boolean - whether this standard matched any type
-            .reduce(function (p, c) { return p || c; }, false);
-    });
-}
-function processStandards(standards) {
+function writeScripts(accessibilities) {
     return __awaiter(this, void 0, void 0, function () {
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0: return [4 /*yield*/, installDependencies(standards)];
-                case 1:
-                    _a.sent();
-                    return [4 /*yield*/, installDevDependencies(standards)];
-                case 2:
-                    _a.sent();
-                    return [4 /*yield*/, copyTemplates(standards)];
-                case 3:
-                    _a.sent();
-                    return [4 /*yield*/, writeScripts(standards)];
-                case 4:
-                    _a.sent();
-                    return [2 /*return*/];
-            }
-        });
-    });
-}
-function installDependencies(standards) {
-    return __awaiter(this, void 0, void 0, function () {
-        var dependencies, e_1;
+        var scripts, pkgJsonPath, pkg;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    dependencies = mergePackageList(standards, 'dependencies');
-                    if (!dependencies.length) return [3 /*break*/, 5];
-                    console.log('> Installing dependencies:', dependencies.join(', '));
-                    _a.label = 1;
-                case 1:
-                    _a.trys.push([1, 3, , 4]);
-                    return [4 /*yield*/, install_packages_1.default({ packages: dependencies })];
-                case 2:
-                    _a.sent();
-                    return [3 /*break*/, 4];
-                case 3:
-                    e_1 = _a.sent();
-                    console.error(e_1);
-                    return [3 /*break*/, 4];
-                case 4: return [3 /*break*/, 6];
-                case 5:
-                    console.warn('> No dependencies provided');
-                    _a.label = 6;
-                case 6: return [2 /*return*/];
-            }
-        });
-    });
-}
-function installDevDependencies(standards) {
-    return __awaiter(this, void 0, void 0, function () {
-        var devDependencies, e_2;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    devDependencies = mergePackageList(standards, 'devDependencies');
-                    devDependencies.push('concurrently');
-                    devDependencies.push('husky');
-                    if (!devDependencies.length) return [3 /*break*/, 5];
-                    console.log('> Installing devDependencies:', devDependencies.join(', '));
-                    _a.label = 1;
-                case 1:
-                    _a.trys.push([1, 3, , 4]);
-                    return [4 /*yield*/, install_packages_1.default({ packages: devDependencies, saveDev: true })];
-                case 2:
-                    _a.sent();
-                    return [3 /*break*/, 4];
-                case 3:
-                    e_2 = _a.sent();
-                    console.error(e_2);
-                    return [3 /*break*/, 4];
-                case 4: return [3 /*break*/, 6];
-                case 5:
-                    console.warn('> No devDependencies provided');
-                    _a.label = 6;
-                case 6: return [2 /*return*/];
-            }
-        });
-    });
-}
-function copyTemplates(standards) {
-    return __awaiter(this, void 0, void 0, function () {
-        var templates;
-        var _this = this;
-        return __generator(this, function (_a) {
-            templates = mergeTemplates(standards);
-            if (templates.length) {
-                console.log('> Installing templates: ', templates.join(', '));
-                templates.forEach(function (template) { return __awaiter(_this, void 0, void 0, function () {
-                    return __generator(this, function (_a) {
-                        switch (_a.label) {
-                            case 0: return [4 /*yield*/, fs_extra_1.default.copy(path_1.default.join(path_1.default.dirname(require.resolve('./gh')), template), process.cwd(), { overwrite: true })];
-                            case 1: return [2 /*return*/, _a.sent()];
-                        }
-                    });
-                }); });
-            }
-            else {
-                console.warn('> No templates provided');
-            }
-            return [2 /*return*/];
-        });
-    });
-}
-function getMainScripts(type, standards) {
-    return ramda_1.default.uniq(ramda_1.default.flatten(standards.map(function (s) {
-        return ramda_1.default.flatten(s.rules
-            .map(function (r) { return (r.type === type && r.mainScript ? r.mainScript : ''); })
-            .filter(Boolean));
-    })));
-}
-var colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
-function createConcurrentScript(scripts, killOthersOnFail) {
-    var k = killOthersOnFail ? ' --kill-others-on-fail' : '';
-    var n = scripts.join(',');
-    var c = colors.slice(0, scripts.length).join(',');
-    var s = scripts.map(function (s) { return "\"" + command + " run " + s + "\""; }).join(' ');
-    return "concurrently" + k + " -n \"" + n + "\" -c \"" + c + "\" " + s;
-}
-function writeScripts(standards) {
-    return __awaiter(this, void 0, void 0, function () {
-        var scripts, precommitScripts, pkgJsonPath, pkg;
-        return __generator(this, function (_a) {
-            switch (_a.label) {
-                case 0:
-                    scripts = __assign({}, mergePackageDictionary(standards, 'scripts'), { a11y: createConcurrentScript(getMainScripts('accessibility', standards)) });
-                    precommitScripts = {
-                        hooks: {
-                            'pre-commit': command + " run format && " + command + " run lint"
-                        }
-                    };
+                    scripts = __assign({}, utility_1.mergePackageDictionary(accessibilities, 'scripts'), { a11y: utility_1.createConcurrentScript(command, utility_1.getMainScripts('accessibility', accessibilities)) });
                     console.log('> Writing scripts to package.json:', Object.keys(scripts).join(', '));
                     pkgJsonPath = path_1.default.join(process.cwd(), 'package.json');
                     pkg = JSON.parse(fs_extra_1.default.readFileSync(pkgJsonPath).toString());
                     pkg.scripts = __assign({}, (pkg.scripts || {}), scripts);
-                    pkg.husky = __assign({}, (pkg.husky || {}), precommitScripts);
                     return [4 /*yield*/, fs_extra_1.default.writeFile(pkgJsonPath, JSON.stringify(pkg, undefined, 2))];
                 case 1:
                     _a.sent();
@@ -235,38 +100,5 @@ function writeScripts(standards) {
             }
         });
     });
-}
-function mergePackageDictionary(standards, field) {
-    return standards
-        .map(function (s) {
-        return s.rules
-            .map(function (r) { return (r.packageChanges ? r.packageChanges[field] : []); })
-            .reduce(function (p, c) { return ramda_1.default.merge(p, c); });
-    })
-        .reduce(function (p, c) { return ramda_1.default.merge(p, c); });
-}
-function mergePackageList(standards, field) {
-    return ramda_1.default.uniq(standards
-        .map(function (s) {
-        return s.rules
-            .map(function (r) {
-            return r.packageChanges && r.packageChanges[field]
-                ? r.packageChanges[field]
-                : [];
-        })
-            .reduce(function (p, c) {
-            if (p === void 0) { p = []; }
-            if (c === void 0) { c = []; }
-            return p.concat(c);
-        });
-    })
-        .reduce(function (p, c) {
-        if (p === void 0) { p = []; }
-        if (c === void 0) { c = []; }
-        return p.concat(c);
-    }) || []);
-}
-function mergeTemplates(standards) {
-    return ramda_1.default.uniq(ramda_1.default.flatten(standards.map(function (s) { return ramda_1.default.flatten(s.rules.map(function (r) { return r.templates || []; })); })));
 }
 start();

--- a/dist/gh-standards.js
+++ b/dist/gh-standards.js
@@ -81,21 +81,25 @@ function processTypes(types) {
         });
     });
 }
-function writeScripts(standards) {
+function writeScripts(selectedStandards) {
     return __awaiter(this, void 0, void 0, function () {
-        var scripts, precommitScripts, pkgJsonPath, pkg;
+        var pkgJsonPath, pkg, currentLintScripts, currentFormatScripts, allLintScripts, allFormatScripts, scripts, precommitScripts;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
-                    scripts = __assign({}, utility_1.mergePackageDictionary(standards, 'scripts'), { lint: utility_1.createConcurrentScript(command, utility_1.getMainScripts('lint', standards)), format: utility_1.createConcurrentScript(command, utility_1.getMainScripts('format', standards)) });
+                    pkgJsonPath = path_1.default.join(process.cwd(), 'package.json');
+                    pkg = JSON.parse(fs_extra_1.default.readFileSync(pkgJsonPath).toString());
+                    currentLintScripts = utility_1.checkConcurrentScript(pkg, 'lint', standards_1.standards);
+                    currentFormatScripts = utility_1.checkConcurrentScript(pkg, 'format', standards_1.standards);
+                    allLintScripts = utility_1.getMainScripts('lint', selectedStandards).concat(currentLintScripts);
+                    allFormatScripts = utility_1.getMainScripts('format', selectedStandards).concat(currentFormatScripts);
+                    scripts = __assign({}, utility_1.mergePackageDictionary(selectedStandards, 'scripts'), { lint: utility_1.createConcurrentScript(command, allLintScripts), format: utility_1.createConcurrentScript(command, allFormatScripts) });
                     precommitScripts = {
                         hooks: {
                             'pre-commit': command + " run format && " + command + " run lint"
                         }
                     };
                     console.log('> Writing scripts to package.json:', Object.keys(scripts).join(', '));
-                    pkgJsonPath = path_1.default.join(process.cwd(), 'package.json');
-                    pkg = JSON.parse(fs_extra_1.default.readFileSync(pkgJsonPath).toString());
                     pkg.scripts = __assign({}, (pkg.scripts || {}), scripts);
                     pkg.husky = __assign({}, (pkg.husky || {}), precommitScripts);
                     return [4 /*yield*/, fs_extra_1.default.writeFile(pkgJsonPath, JSON.stringify(pkg, undefined, 2))];

--- a/dist/gh-standards.js
+++ b/dist/gh-standards.js
@@ -83,7 +83,7 @@ function processTypes(types) {
 }
 function writeScripts(selectedStandards) {
     return __awaiter(this, void 0, void 0, function () {
-        var pkgJsonPath, pkg, currentLintScripts, currentFormatScripts, allLintScripts, allFormatScripts, scripts, precommitScripts;
+        var pkgJsonPath, pkg, currentLintScripts, currentFormatScripts, allLintScripts, allFormatScripts, allUniqueLintScripts, allUniqueFormatScripts, scripts, precommitScripts;
         return __generator(this, function (_a) {
             switch (_a.label) {
                 case 0:
@@ -93,7 +93,9 @@ function writeScripts(selectedStandards) {
                     currentFormatScripts = utility_1.checkConcurrentScript(pkg, 'format', standards_1.standards);
                     allLintScripts = utility_1.getMainScripts('lint', selectedStandards).concat(currentLintScripts);
                     allFormatScripts = utility_1.getMainScripts('format', selectedStandards).concat(currentFormatScripts);
-                    scripts = __assign({}, utility_1.mergePackageDictionary(selectedStandards, 'scripts'), { lint: utility_1.createConcurrentScript(command, allLintScripts), format: utility_1.createConcurrentScript(command, allFormatScripts) });
+                    allUniqueLintScripts = allLintScripts.filter(function (script, index) { return allLintScripts.indexOf(script) === index; });
+                    allUniqueFormatScripts = allFormatScripts.filter(function (script, index) { return allFormatScripts.indexOf(script) === index; });
+                    scripts = __assign({}, utility_1.mergePackageDictionary(selectedStandards, 'scripts'), { lint: utility_1.createConcurrentScript(command, allUniqueLintScripts), format: utility_1.createConcurrentScript(command, allUniqueFormatScripts) });
                     precommitScripts = {
                         hooks: {
                             'pre-commit': command + " run format && " + command + " run lint"

--- a/dist/gh.js
+++ b/dist/gh.js
@@ -8,4 +8,5 @@ var commander_1 = __importDefault(require("commander"));
 commander_1.default
     .version('1.0.0')
     .command('standards [types]', 'add standards for js, ts, and/or scss.')
+    .command('accessibility [types]', 'add accessibility tools axe, pa11y, and/or lighthouse.').alias('a11y')
     .parse(process.argv);

--- a/dist/gh.js
+++ b/dist/gh.js
@@ -8,5 +8,6 @@ var commander_1 = __importDefault(require("commander"));
 commander_1.default
     .version('1.0.0')
     .command('standards [types]', 'add standards for js, ts, and/or scss.')
-    .command('accessibility [types]', 'add accessibility tools axe, pa11y, and/or lighthouse.').alias('a11y')
+    .command('accessibility [types]', 'add accessibility tools axe, pa11y, and/or lighthouse.')
+    .alias('a11y')
     .parse(process.argv);

--- a/dist/rules.js
+++ b/dist/rules.js
@@ -38,7 +38,7 @@ exports.createPrettierRule = createPrettierRule;
 /** Create a new accessibility rule */
 function createAccessibilityRule(options) {
     return {
-        type: 'accessibility',
+        type: 'a11y',
         name: options.name,
         description: options.description,
         packageChanges: options.packageChanges,

--- a/dist/rules.js
+++ b/dist/rules.js
@@ -42,7 +42,7 @@ function createAccessibilityRule(options) {
         name: options.name,
         description: options.description,
         packageChanges: options.packageChanges,
-        mainScript: options.mainScript,
+        mainScript: options.mainScript
     };
 }
 exports.createAccessibilityRule = createAccessibilityRule;

--- a/dist/rules.js
+++ b/dist/rules.js
@@ -35,3 +35,14 @@ function createPrettierRule(options) {
     });
 }
 exports.createPrettierRule = createPrettierRule;
+/** Create a new accessibility rule */
+function createAccessibilityRule(options) {
+    return {
+        type: 'accessibility',
+        name: options.name,
+        description: options.description,
+        packageChanges: options.packageChanges,
+        mainScript: options.mainScript,
+    };
+}
+exports.createAccessibilityRule = createAccessibilityRule;

--- a/dist/standards.js
+++ b/dist/standards.js
@@ -103,10 +103,10 @@ exports.axe = {
             packageChanges: {
                 devDependencies: ['axe-cli'],
                 scripts: {
-                    'a11y:axe': 'axe http://localhost --tags wcag2a,wcag2aa,best-practice --browser chrome',
+                    'a11y:axe': 'axe http://localhost --tags wcag2a,wcag2aa,best-practice --browser chrome'
                 }
             },
-            mainScript: 'a11y:axe',
+            mainScript: 'a11y:axe'
         })
     ]
 };
@@ -125,7 +125,7 @@ exports.pa11y = {
                     'a11y:pa11y': 'pa11y http://localhost --standard WCAG2AA'
                 }
             },
-            mainScript: 'a11y:pa11y',
+            mainScript: 'a11y:pa11y'
         })
     ]
 };
@@ -144,7 +144,7 @@ exports.lighthouse = {
                     'a11y:lighthouse': 'lighthouse http://localhost --output json --output-path ./lighthouse-report.json'
                 }
             },
-            mainScript: 'a11y:lighthouse',
+            mainScript: 'a11y:lighthouse'
         })
     ]
 };

--- a/dist/standards.js
+++ b/dist/standards.js
@@ -91,5 +91,64 @@ exports.scss = {
         })
     ]
 };
+/** Axe Accessibility Tool */
+exports.axe = {
+    name: 'Axe',
+    keywords: ['axe', 'axe-cli'],
+    description: 'Axe accessibility tool',
+    rules: [
+        rules_1.createAccessibilityRule({
+            name: 'Axe',
+            description: 'Axe accessibility rule',
+            packageChanges: {
+                devDependencies: ['axe-cli'],
+                scripts: {
+                    'a11y:axe': 'axe http://localhost --tags wcag2a,wcag2aa,best-practice --browser chrome',
+                }
+            },
+            mainScript: 'a11y:axe',
+        })
+    ]
+};
+/** Pa11y  Accessibility Tool */
+exports.pa11y = {
+    name: 'Pa11y',
+    keywords: ['pa11y'],
+    description: 'Pa11y accessibility tool',
+    rules: [
+        rules_1.createAccessibilityRule({
+            name: 'Pa11Y',
+            description: 'Pa11y accessibility tool',
+            packageChanges: {
+                devDependencies: ['pa11y'],
+                scripts: {
+                    'a11y:pa11y': 'pa11y http://localhost --standard WCAG2AA'
+                }
+            },
+            mainScript: 'a11y:pa11y',
+        })
+    ]
+};
+/** Lighthouse  Accessibility Tool */
+exports.lighthouse = {
+    name: 'Lighthouse',
+    keywords: ['lighthouse'],
+    description: 'Lighthouse accessibility tool',
+    rules: [
+        rules_1.createAccessibilityRule({
+            name: 'Lighthouse',
+            description: 'Lighthouse accessibility tool',
+            packageChanges: {
+                devDependencies: ['lighthouse'],
+                scripts: {
+                    'a11y:lighthouse': 'lighthouse http://localhost --output json --output-path ./lighthouse-report.json'
+                }
+            },
+            mainScript: 'a11y:lighthouse',
+        })
+    ]
+};
 /** Supported standards */
 exports.standards = [exports.javaScript, exports.typeScript, exports.scss];
+/** Supported accessibility tools */
+exports.accessibilities = [exports.axe, exports.pa11y, exports.lighthouse];

--- a/dist/utility.js
+++ b/dist/utility.js
@@ -1,0 +1,211 @@
+"use strict";
+var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, generator) {
+    return new (P || (P = Promise))(function (resolve, reject) {
+        function fulfilled(value) { try { step(generator.next(value)); } catch (e) { reject(e); } }
+        function rejected(value) { try { step(generator["throw"](value)); } catch (e) { reject(e); } }
+        function step(result) { result.done ? resolve(result.value) : new P(function (resolve) { resolve(result.value); }).then(fulfilled, rejected); }
+        step((generator = generator.apply(thisArg, _arguments || [])).next());
+    });
+};
+var __generator = (this && this.__generator) || function (thisArg, body) {
+    var _ = { label: 0, sent: function() { if (t[0] & 1) throw t[1]; return t[1]; }, trys: [], ops: [] }, f, y, t, g;
+    return g = { next: verb(0), "throw": verb(1), "return": verb(2) }, typeof Symbol === "function" && (g[Symbol.iterator] = function() { return this; }), g;
+    function verb(n) { return function (v) { return step([n, v]); }; }
+    function step(op) {
+        if (f) throw new TypeError("Generator is already executing.");
+        while (_) try {
+            if (f = 1, y && (t = op[0] & 2 ? y["return"] : op[0] ? y["throw"] || ((t = y["return"]) && t.call(y), 0) : y.next) && !(t = t.call(y, op[1])).done) return t;
+            if (y = 0, t) op = [op[0] & 2, t.value];
+            switch (op[0]) {
+                case 0: case 1: t = op; break;
+                case 4: _.label++; return { value: op[1], done: false };
+                case 5: _.label++; y = op[1]; op = [0]; continue;
+                case 7: op = _.ops.pop(); _.trys.pop(); continue;
+                default:
+                    if (!(t = _.trys, t = t.length > 0 && t[t.length - 1]) && (op[0] === 6 || op[0] === 2)) { _ = 0; continue; }
+                    if (op[0] === 3 && (!t || (op[1] > t[0] && op[1] < t[3]))) { _.label = op[1]; break; }
+                    if (op[0] === 6 && _.label < t[1]) { _.label = t[1]; t = op; break; }
+                    if (t && _.label < t[2]) { _.label = t[2]; _.ops.push(op); break; }
+                    if (t[2]) _.ops.pop();
+                    _.trys.pop(); continue;
+            }
+            op = body.call(thisArg, _);
+        } catch (e) { op = [6, e]; y = 0; } finally { f = t = 0; }
+        if (op[0] & 5) throw op[1]; return { value: op[0] ? op[1] : void 0, done: true };
+    }
+};
+var __importDefault = (this && this.__importDefault) || function (mod) {
+    return (mod && mod.__esModule) ? mod : { "default": mod };
+};
+Object.defineProperty(exports, "__esModule", { value: true });
+var fs_extra_1 = __importDefault(require("fs-extra"));
+var install_packages_1 = __importDefault(require("install-packages"));
+var path_1 = __importDefault(require("path"));
+var ramda_1 = __importDefault(require("ramda"));
+function getSelectedStandards(standards, types) {
+    return standards.filter(function (standard) {
+        return types
+            // string[] -> boolean[] - whether any keyword of this standard matched the current type
+            .map(function (type) { return standard.keywords.reduce(function (p, c) { return p || c === type; }, false); })
+            // boolean[] -> boolean - whether this standard matched any type
+            .reduce(function (p, c) { return p || c; }, false);
+    });
+}
+exports.getSelectedStandards = getSelectedStandards;
+function processStandards(standards, writeScripts) {
+    return __awaiter(this, void 0, void 0, function () {
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0: return [4 /*yield*/, installDependencies(standards)];
+                case 1:
+                    _a.sent();
+                    return [4 /*yield*/, installDevDependencies(standards)];
+                case 2:
+                    _a.sent();
+                    return [4 /*yield*/, copyTemplates(standards)];
+                case 3:
+                    _a.sent();
+                    return [4 /*yield*/, writeScripts(standards)];
+                case 4:
+                    _a.sent();
+                    return [2 /*return*/];
+            }
+        });
+    });
+}
+exports.processStandards = processStandards;
+function installDependencies(standards) {
+    return __awaiter(this, void 0, void 0, function () {
+        var dependencies, e_1;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    dependencies = mergePackageList(standards, 'dependencies');
+                    if (!dependencies.length) return [3 /*break*/, 5];
+                    console.log('> Installing dependencies:', dependencies.join(', '));
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, 3, , 4]);
+                    return [4 /*yield*/, install_packages_1.default({ packages: dependencies })];
+                case 2:
+                    _a.sent();
+                    return [3 /*break*/, 4];
+                case 3:
+                    e_1 = _a.sent();
+                    console.error(e_1);
+                    return [3 /*break*/, 4];
+                case 4: return [3 /*break*/, 6];
+                case 5:
+                    console.warn('> No dependencies provided');
+                    _a.label = 6;
+                case 6: return [2 /*return*/];
+            }
+        });
+    });
+}
+function installDevDependencies(standards) {
+    return __awaiter(this, void 0, void 0, function () {
+        var devDependencies, e_2;
+        return __generator(this, function (_a) {
+            switch (_a.label) {
+                case 0:
+                    devDependencies = mergePackageList(standards, 'devDependencies');
+                    devDependencies.push('concurrently');
+                    devDependencies.push('husky');
+                    if (!devDependencies.length) return [3 /*break*/, 5];
+                    console.log('> Installing devDependencies:', devDependencies.join(', '));
+                    _a.label = 1;
+                case 1:
+                    _a.trys.push([1, 3, , 4]);
+                    return [4 /*yield*/, install_packages_1.default({ packages: devDependencies, saveDev: true })];
+                case 2:
+                    _a.sent();
+                    return [3 /*break*/, 4];
+                case 3:
+                    e_2 = _a.sent();
+                    console.error(e_2);
+                    return [3 /*break*/, 4];
+                case 4: return [3 /*break*/, 6];
+                case 5:
+                    console.warn('> No devDependencies provided');
+                    _a.label = 6;
+                case 6: return [2 /*return*/];
+            }
+        });
+    });
+}
+function copyTemplates(standards) {
+    return __awaiter(this, void 0, void 0, function () {
+        var templates;
+        var _this = this;
+        return __generator(this, function (_a) {
+            templates = mergeTemplates(standards);
+            if (templates.length) {
+                console.log('> Installing templates: ', templates.join(', '));
+                templates.forEach(function (template) { return __awaiter(_this, void 0, void 0, function () {
+                    return __generator(this, function (_a) {
+                        switch (_a.label) {
+                            case 0: return [4 /*yield*/, fs_extra_1.default.copy(path_1.default.join(path_1.default.dirname(require.resolve('./gh')), template), process.cwd(), { overwrite: true })];
+                            case 1: return [2 /*return*/, _a.sent()];
+                        }
+                    });
+                }); });
+            }
+            else {
+                console.warn('> No templates provided');
+            }
+            return [2 /*return*/];
+        });
+    });
+}
+function getMainScripts(type, standards) {
+    return ramda_1.default.uniq(ramda_1.default.flatten(standards.map(function (s) {
+        return ramda_1.default.flatten(s.rules
+            .map(function (r) { return (r.type === type && r.mainScript ? r.mainScript : ''); })
+            .filter(Boolean));
+    })));
+}
+exports.getMainScripts = getMainScripts;
+var colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
+function createConcurrentScript(command, scripts, killOthersOnFail) {
+    var k = killOthersOnFail ? ' --kill-others-on-fail' : '';
+    var n = scripts.join(',');
+    var c = colors.slice(0, scripts.length).join(',');
+    var s = scripts.map(function (s) { return "\"" + command + " run " + s + "\""; }).join(' ');
+    return "concurrently" + k + " -n \"" + n + "\" -c \"" + c + "\" " + s;
+}
+exports.createConcurrentScript = createConcurrentScript;
+function mergePackageDictionary(standards, field) {
+    return standards
+        .map(function (s) {
+        return s.rules
+            .map(function (r) { return (r.packageChanges ? r.packageChanges[field] : []); })
+            .reduce(function (p, c) { return ramda_1.default.merge(p, c); });
+    })
+        .reduce(function (p, c) { return ramda_1.default.merge(p, c); });
+}
+exports.mergePackageDictionary = mergePackageDictionary;
+function mergePackageList(standards, field) {
+    return ramda_1.default.uniq(standards
+        .map(function (s) {
+        return s.rules
+            .map(function (r) {
+            return r.packageChanges && r.packageChanges[field]
+                ? r.packageChanges[field]
+                : [];
+        })
+            .reduce(function (p, c) {
+            if (p === void 0) { p = []; }
+            if (c === void 0) { c = []; }
+            return p.concat(c);
+        });
+    })
+        .reduce(function (p, c) {
+        if (p === void 0) { p = []; }
+        if (c === void 0) { c = []; }
+        return p.concat(c);
+    }) || []);
+}
+function mergeTemplates(standards) {
+    return ramda_1.default.uniq(ramda_1.default.flatten(standards.map(function (s) { return ramda_1.default.flatten(s.rules.map(function (r) { return r.templates || []; })); })));
+}

--- a/dist/utility.js
+++ b/dist/utility.js
@@ -172,9 +172,9 @@ function checkConcurrentScript(pkg, type, standards) {
     var concurrentScript = pkg.scripts[type];
     if (concurrentScript) {
         standards.forEach(function (standard) {
-            if (concurrentScript.includes(standard.keywords[0]) &&
-                standard.rules[0].mainScript) {
-                currentScripts.push(standard.rules[0].mainScript);
+            var rule = standard.rules.filter(function (rule) { return rule.type === type; })[0];
+            if (concurrentScript.includes(standard.keywords[0]) && rule.mainScript) {
+                currentScripts.push(rule.mainScript);
             }
         });
     }

--- a/dist/utility.js
+++ b/dist/utility.js
@@ -167,6 +167,20 @@ function getMainScripts(type, standards) {
 }
 exports.getMainScripts = getMainScripts;
 var colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
+function checkConcurrentScript(pkg, type, standards) {
+    var currentScripts = [];
+    var concurrentScript = pkg.scripts[type];
+    if (concurrentScript) {
+        standards.forEach(function (standard) {
+            if (concurrentScript.includes(standard.keywords[0]) &&
+                standard.rules[0].mainScript) {
+                currentScripts.push(standard.rules[0].mainScript);
+            }
+        });
+    }
+    return currentScripts;
+}
+exports.checkConcurrentScript = checkConcurrentScript;
 function createConcurrentScript(command, scripts, killOthersOnFail) {
     var k = killOthersOnFail ? ' --kill-others-on-fail' : '';
     var n = scripts.join(',');

--- a/src/gh-accessibility.ts
+++ b/src/gh-accessibility.ts
@@ -117,7 +117,7 @@ function createConcurrentScript(
 async function writeScripts(standards: Standard[]): Promise<void> {
   const scripts = {
     ...mergePackageDictionary(standards, 'scripts'),
-    a11y: createConcurrentScript(getMainScripts('accessibility', standards)),
+    a11y: createConcurrentScript(getMainScripts('accessibility', standards))
   };
 
   const precommitScripts = {

--- a/src/gh-accessibility.ts
+++ b/src/gh-accessibility.ts
@@ -4,9 +4,14 @@ import program from 'commander';
 import fs from 'fs-extra';
 import install from 'install-packages';
 import path from 'path';
-import R, { Dictionary } from 'ramda';
-import { PackageChanges, RuleType } from './rules';
 import { accessibilities, Standard } from './standards';
+import {
+  createConcurrentScript,
+  getMainScripts,
+  getSelectedStandards,
+  mergePackageDictionary,
+  processStandards
+} from './utility';
 
 let command = 'npm';
 
@@ -22,108 +27,19 @@ function start() {
 
 async function processTypes(types: string[]) {
   command = await install.determinePackageManager(process.cwd());
-  await processStandards(getSelectedStandards(types));
-}
-
-function getSelectedStandards(types: string[]) {
-  return accessibilities.filter(standard =>
-    types
-      // string[] -> boolean[] - whether any keyword of this standard matched the current type
-      .map(type => standard.keywords.reduce((p, c) => p || c === type, false))
-      // boolean[] -> boolean - whether this standard matched any type
-      .reduce((p, c) => p || c, false)
+  await processStandards(
+    getSelectedStandards(accessibilities, types),
+    writeScripts
   );
 }
 
-async function processStandards(standards: Standard[]): Promise<void> {
-  await installDependencies(standards);
-  await installDevDependencies(standards);
-  await copyTemplates(standards);
-  await writeScripts(standards);
-}
-
-async function installDependencies(standards: Standard[]): Promise<void> {
-  const dependencies = mergePackageList(standards, 'dependencies');
-  if (dependencies.length) {
-    console.log('> Installing dependencies:', dependencies.join(', '));
-    try {
-      await install({ packages: dependencies });
-    } catch (e) {
-      console.error(e);
-    }
-  } else {
-    console.warn('> No dependencies provided');
-  }
-}
-
-async function installDevDependencies(standards: Standard[]): Promise<void> {
-  const devDependencies = mergePackageList(standards, 'devDependencies');
-  devDependencies.push('concurrently');
-  devDependencies.push('husky');
-  if (devDependencies.length) {
-    console.log('> Installing devDependencies:', devDependencies.join(', '));
-    try {
-      await install({ packages: devDependencies, saveDev: true });
-    } catch (e) {
-      console.error(e);
-    }
-  } else {
-    console.warn('> No devDependencies provided');
-  }
-}
-
-async function copyTemplates(standards: Standard[]): Promise<void> {
-  const templates = mergeTemplates(standards);
-  if (templates.length) {
-    console.log('> Installing templates: ', templates.join(', '));
-    templates.forEach(
-      async template =>
-        await fs.copy(
-          path.join(path.dirname(require.resolve('./gh')), template),
-          process.cwd(),
-          { overwrite: true }
-        )
-    );
-  } else {
-    console.warn('> No templates provided');
-  }
-}
-
-function getMainScripts(type: RuleType, standards: Standard[]): string[] {
-  return R.uniq((R.flatten(
-    standards.map(s =>
-      R.flatten(
-        s.rules
-          .map(r => (r.type === type && r.mainScript ? r.mainScript : ''))
-          .filter(Boolean)
-      )
-    )
-  ) as any) as string[]);
-}
-
-const colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
-
-function createConcurrentScript(
-  scripts: string[],
-  killOthersOnFail?: boolean
-): string {
-  const k = killOthersOnFail ? ' --kill-others-on-fail' : '';
-  const n = scripts.join(',');
-  const c = colors.slice(0, scripts.length).join(',');
-  const s = scripts.map(s => `\"${command} run ${s}\"`).join(' ');
-  return `concurrently${k} -n \"${n}\" -c \"${c}\" ${s}`;
-}
-
-async function writeScripts(standards: Standard[]): Promise<void> {
+async function writeScripts(accessibilities: Standard[]): Promise<void> {
   const scripts = {
-    ...mergePackageDictionary(standards, 'scripts'),
-    a11y: createConcurrentScript(getMainScripts('accessibility', standards))
-  };
-
-  const precommitScripts = {
-    hooks: {
-      'pre-commit': `${command} run format && ${command} run lint`
-    }
+    ...mergePackageDictionary(accessibilities, 'scripts'),
+    a11y: createConcurrentScript(
+      command,
+      getMainScripts('accessibility', accessibilities)
+    )
   };
 
   console.log(
@@ -133,46 +49,7 @@ async function writeScripts(standards: Standard[]): Promise<void> {
   const pkgJsonPath = path.join(process.cwd(), 'package.json');
   const pkg = JSON.parse(fs.readFileSync(pkgJsonPath).toString());
   pkg.scripts = { ...(pkg.scripts || {}), ...scripts };
-  pkg.husky = { ...(pkg.husky || {}), ...precommitScripts };
   await fs.writeFile(pkgJsonPath, JSON.stringify(pkg, undefined, 2));
-}
-
-function mergePackageDictionary<
-  K extends keyof Pick<PackageChanges, 'scripts'>
->(standards: Standard[], field: K): Dictionary<string> {
-  return standards
-    .map(s =>
-      s.rules
-        .map(r => (r.packageChanges ? r.packageChanges[field] : []))
-        .reduce((p, c) => R.merge(p, c))
-    )
-    .reduce((p, c) => R.merge(p, c)) as Dictionary<string>;
-}
-
-function mergePackageList<
-  K extends keyof Pick<PackageChanges, 'dependencies' | 'devDependencies'>
->(standards: Standard[], field: K): string[] {
-  return R.uniq(
-    standards
-      .map(s =>
-        s.rules
-          .map(r =>
-            r.packageChanges && r.packageChanges[field]
-              ? (r.packageChanges[field] as string[])
-              : []
-          )
-          .reduce((p = [], c = []) => [...p, ...c])
-      )
-      .reduce((p = [], c = []) => [...p, ...c]) || []
-  );
-}
-
-function mergeTemplates(standards: Standard[]): string[] {
-  return (R.uniq(
-    R.flatten(
-      standards.map(s => R.flatten(s.rules.map(r => r.templates || [])))
-    )
-  ) as any) as string[];
 }
 
 start();

--- a/src/gh-accessibility.ts
+++ b/src/gh-accessibility.ts
@@ -57,9 +57,12 @@ async function writeScripts(selectedStandards: Standard[]): Promise<void> {
     'a11y',
     selectedStandards
   ).concat(currentScripts);
+  const allUniqueScripts = allMainScripts.filter(
+    (script, index) => allMainScripts.indexOf(script) === index
+  );
   const scripts = {
     ...mergePackageDictionary(selectedStandards, 'scripts'),
-    a11y: createConcurrentScript(command, allMainScripts)
+    a11y: createConcurrentScript(command, allUniqueScripts)
   };
   console.log(
     '> Writing scripts to package.json:',

--- a/src/gh-accessibility.ts
+++ b/src/gh-accessibility.ts
@@ -6,6 +6,7 @@ import install from 'install-packages';
 import path from 'path';
 import { accessibilities, Standard } from './standards';
 import {
+  checkConcurrentScript,
   createConcurrentScript,
   getMainScripts,
   getSelectedStandards,
@@ -19,7 +20,18 @@ function start() {
   program.parse(process.argv);
   if (!program.args.length) {
     // Add all accessibility tools if list of arguments is omitted
-    processTypes(['axe', 'pa11y', 'lighthouse']);
+    const pkgJsonPath = path.join(process.cwd(), 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgJsonPath).toString());
+    const allAccessibilities = ['axe', 'pa11y', 'lighthouse'];
+    const currentScripts: string[] = checkConcurrentScript(
+      pkg,
+      'a11y',
+      accessibilities
+    );
+    const allTypes = allAccessibilities.filter(
+      type => currentScripts.indexOf(`a11y:${type}`) === -1
+    );
+    processTypes(allTypes);
   } else {
     processTypes(program.args);
   }
@@ -33,21 +45,26 @@ async function processTypes(types: string[]) {
   );
 }
 
-async function writeScripts(accessibilities: Standard[]): Promise<void> {
+async function writeScripts(selectedStandards: Standard[]): Promise<void> {
+  const pkgJsonPath = path.join(process.cwd(), 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath).toString());
+  const currentScripts: string[] = checkConcurrentScript(
+    pkg,
+    'a11y',
+    accessibilities
+  );
+  const allMainScripts: string[] = getMainScripts(
+    'a11y',
+    selectedStandards
+  ).concat(currentScripts);
   const scripts = {
-    ...mergePackageDictionary(accessibilities, 'scripts'),
-    a11y: createConcurrentScript(
-      command,
-      getMainScripts('accessibility', accessibilities)
-    )
+    ...mergePackageDictionary(selectedStandards, 'scripts'),
+    a11y: createConcurrentScript(command, allMainScripts)
   };
-
   console.log(
     '> Writing scripts to package.json:',
     Object.keys(scripts).join(', ')
   );
-  const pkgJsonPath = path.join(process.cwd(), 'package.json');
-  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath).toString());
   pkg.scripts = { ...(pkg.scripts || {}), ...scripts };
   await fs.writeFile(pkgJsonPath, JSON.stringify(pkg, undefined, 2));
 }

--- a/src/gh-accessibility.ts
+++ b/src/gh-accessibility.ts
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+
+import program from 'commander';
+import fs from 'fs-extra';
+import install from 'install-packages';
+import path from 'path';
+import R, { Dictionary } from 'ramda';
+import { PackageChanges, RuleType } from './rules';
+import { accessibilities, Standard } from './standards';
+
+let command = 'npm';
+
+function start() {
+  program.parse(process.argv);
+  if (!program.args.length) {
+    // Add all accessibility tools if list of arguments is omitted
+    processTypes(['axe', 'pa11y', 'lighthouse']);
+  } else {
+    processTypes(program.args);
+  }
+}
+
+async function processTypes(types: string[]) {
+  command = await install.determinePackageManager(process.cwd());
+  await processStandards(getSelectedStandards(types));
+}
+
+function getSelectedStandards(types: string[]) {
+  return accessibilities.filter(standard =>
+    types
+      // string[] -> boolean[] - whether any keyword of this standard matched the current type
+      .map(type => standard.keywords.reduce((p, c) => p || c === type, false))
+      // boolean[] -> boolean - whether this standard matched any type
+      .reduce((p, c) => p || c, false)
+  );
+}
+
+async function processStandards(standards: Standard[]): Promise<void> {
+  await installDependencies(standards);
+  await installDevDependencies(standards);
+  await copyTemplates(standards);
+  await writeScripts(standards);
+}
+
+async function installDependencies(standards: Standard[]): Promise<void> {
+  const dependencies = mergePackageList(standards, 'dependencies');
+  if (dependencies.length) {
+    console.log('> Installing dependencies:', dependencies.join(', '));
+    try {
+      await install({ packages: dependencies });
+    } catch (e) {
+      console.error(e);
+    }
+  } else {
+    console.warn('> No dependencies provided');
+  }
+}
+
+async function installDevDependencies(standards: Standard[]): Promise<void> {
+  const devDependencies = mergePackageList(standards, 'devDependencies');
+  devDependencies.push('concurrently');
+  devDependencies.push('husky');
+  if (devDependencies.length) {
+    console.log('> Installing devDependencies:', devDependencies.join(', '));
+    try {
+      await install({ packages: devDependencies, saveDev: true });
+    } catch (e) {
+      console.error(e);
+    }
+  } else {
+    console.warn('> No devDependencies provided');
+  }
+}
+
+async function copyTemplates(standards: Standard[]): Promise<void> {
+  const templates = mergeTemplates(standards);
+  if (templates.length) {
+    console.log('> Installing templates: ', templates.join(', '));
+    templates.forEach(
+      async template =>
+        await fs.copy(
+          path.join(path.dirname(require.resolve('./gh')), template),
+          process.cwd(),
+          { overwrite: true }
+        )
+    );
+  } else {
+    console.warn('> No templates provided');
+  }
+}
+
+function getMainScripts(type: RuleType, standards: Standard[]): string[] {
+  return R.uniq((R.flatten(
+    standards.map(s =>
+      R.flatten(
+        s.rules
+          .map(r => (r.type === type && r.mainScript ? r.mainScript : ''))
+          .filter(Boolean)
+      )
+    )
+  ) as any) as string[]);
+}
+
+const colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
+
+function createConcurrentScript(
+  scripts: string[],
+  killOthersOnFail?: boolean
+): string {
+  const k = killOthersOnFail ? ' --kill-others-on-fail' : '';
+  const n = scripts.join(',');
+  const c = colors.slice(0, scripts.length).join(',');
+  const s = scripts.map(s => `\"${command} run ${s}\"`).join(' ');
+  return `concurrently${k} -n \"${n}\" -c \"${c}\" ${s}`;
+}
+
+async function writeScripts(standards: Standard[]): Promise<void> {
+  const scripts = {
+    ...mergePackageDictionary(standards, 'scripts'),
+    a11y: createConcurrentScript(getMainScripts('accessibility', standards)),
+  };
+
+  const precommitScripts = {
+    hooks: {
+      'pre-commit': `${command} run format && ${command} run lint`
+    }
+  };
+
+  console.log(
+    '> Writing scripts to package.json:',
+    Object.keys(scripts).join(', ')
+  );
+  const pkgJsonPath = path.join(process.cwd(), 'package.json');
+  const pkg = JSON.parse(fs.readFileSync(pkgJsonPath).toString());
+  pkg.scripts = { ...(pkg.scripts || {}), ...scripts };
+  pkg.husky = { ...(pkg.husky || {}), ...precommitScripts };
+  await fs.writeFile(pkgJsonPath, JSON.stringify(pkg, undefined, 2));
+}
+
+function mergePackageDictionary<
+  K extends keyof Pick<PackageChanges, 'scripts'>
+>(standards: Standard[], field: K): Dictionary<string> {
+  return standards
+    .map(s =>
+      s.rules
+        .map(r => (r.packageChanges ? r.packageChanges[field] : []))
+        .reduce((p, c) => R.merge(p, c))
+    )
+    .reduce((p, c) => R.merge(p, c)) as Dictionary<string>;
+}
+
+function mergePackageList<
+  K extends keyof Pick<PackageChanges, 'dependencies' | 'devDependencies'>
+>(standards: Standard[], field: K): string[] {
+  return R.uniq(
+    standards
+      .map(s =>
+        s.rules
+          .map(r =>
+            r.packageChanges && r.packageChanges[field]
+              ? (r.packageChanges[field] as string[])
+              : []
+          )
+          .reduce((p = [], c = []) => [...p, ...c])
+      )
+      .reduce((p = [], c = []) => [...p, ...c]) || []
+  );
+}
+
+function mergeTemplates(standards: Standard[]): string[] {
+  return (R.uniq(
+    R.flatten(
+      standards.map(s => R.flatten(s.rules.map(r => r.templates || [])))
+    )
+  ) as any) as string[];
+}
+
+start();

--- a/src/gh-standards.ts
+++ b/src/gh-standards.ts
@@ -52,10 +52,16 @@ async function writeScripts(selectedStandards: Standard[]): Promise<void> {
     'format',
     selectedStandards
   ).concat(currentFormatScripts);
+  const allUniqueLintScripts = allLintScripts.filter(
+    (script, index) => allLintScripts.indexOf(script) === index
+  );
+  const allUniqueFormatScripts = allFormatScripts.filter(
+    (script, index) => allFormatScripts.indexOf(script) === index
+  );
   const scripts = {
     ...mergePackageDictionary(selectedStandards, 'scripts'),
-    lint: createConcurrentScript(command, allLintScripts),
-    format: createConcurrentScript(command, allFormatScripts)
+    lint: createConcurrentScript(command, allUniqueLintScripts),
+    format: createConcurrentScript(command, allUniqueFormatScripts)
   };
 
   const precommitScripts = {

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -5,4 +5,5 @@ import program from 'commander';
 program
   .version('1.0.0')
   .command('standards [types]', 'add standards for js, ts, and/or scss.')
+  .command('accessibility [types]', 'add accessibility tools axe, pa11y, and/or lighthouse.').alias('a11y')
   .parse(process.argv);

--- a/src/gh.ts
+++ b/src/gh.ts
@@ -5,5 +5,9 @@ import program from 'commander';
 program
   .version('1.0.0')
   .command('standards [types]', 'add standards for js, ts, and/or scss.')
-  .command('accessibility [types]', 'add accessibility tools axe, pa11y, and/or lighthouse.').alias('a11y')
+  .command(
+    'accessibility [types]',
+    'add accessibility tools axe, pa11y, and/or lighthouse.'
+  )
+  .alias('a11y')
   .parse(process.argv);

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -83,12 +83,14 @@ export type AccessibilityRuleOptions = Pick<
 >;
 
 /** Create a new accessibility rule */
-export function createAccessibilityRule(options: AccessibilityRuleOptions): Rule {
+export function createAccessibilityRule(
+  options: AccessibilityRuleOptions
+): Rule {
   return {
     type: 'accessibility',
     name: options.name,
     description: options.description,
     packageChanges: options.packageChanges,
-    mainScript: options.mainScript,
+    mainScript: options.mainScript
   };
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,5 +1,5 @@
 /** Supported rule types */
-export type RuleType = 'lint' | 'format';
+export type RuleType = 'lint' | 'format' | 'accessibility';
 
 /** Dictionary of scripts */
 export interface Scripts {
@@ -74,4 +74,21 @@ export function createPrettierRule(options: PrettierRuleOptions): Rule {
     mainScript: options.mainScript,
     templates: ['../templates/format/']
   });
+}
+
+/** Accessibility rule options */
+export type AccessibilityRuleOptions = Pick<
+  Rule,
+  'name' | 'description' | 'packageChanges' | 'mainScript'
+>;
+
+/** Create a new accessibility rule */
+export function createAccessibilityRule(options: AccessibilityRuleOptions): Rule {
+  return {
+    type: 'accessibility',
+    name: options.name,
+    description: options.description,
+    packageChanges: options.packageChanges,
+    mainScript: options.mainScript,
+  };
 }

--- a/src/rules.ts
+++ b/src/rules.ts
@@ -1,5 +1,5 @@
 /** Supported rule types */
-export type RuleType = 'lint' | 'format' | 'accessibility';
+export type RuleType = 'lint' | 'format' | 'a11y';
 
 /** Dictionary of scripts */
 export interface Scripts {
@@ -87,7 +87,7 @@ export function createAccessibilityRule(
   options: AccessibilityRuleOptions
 ): Rule {
   return {
-    type: 'accessibility',
+    type: 'a11y',
     name: options.name,
     description: options.description,
     packageChanges: options.packageChanges,

--- a/src/standards.ts
+++ b/src/standards.ts
@@ -1,4 +1,9 @@
-import { createLintRule, createPrettierRule, Rule, createAccessibilityRule } from './rules';
+import {
+  createLintRule,
+  createPrettierRule,
+  Rule,
+  createAccessibilityRule
+} from './rules';
 
 /** A collection of rules for a language. */
 export interface Standard {
@@ -113,10 +118,11 @@ export const axe: Standard = {
       packageChanges: {
         devDependencies: ['axe-cli'],
         scripts: {
-          'a11y:axe': 'axe http://localhost --tags wcag2a,wcag2aa,best-practice --browser chrome',
+          'a11y:axe':
+            'axe http://localhost --tags wcag2a,wcag2aa,best-practice --browser chrome'
         }
       },
-      mainScript: 'a11y:axe',
+      mainScript: 'a11y:axe'
     })
   ]
 };
@@ -136,7 +142,7 @@ export const pa11y: Standard = {
           'a11y:pa11y': 'pa11y http://localhost --standard WCAG2AA'
         }
       },
-      mainScript: 'a11y:pa11y',
+      mainScript: 'a11y:pa11y'
     })
   ]
 };
@@ -153,10 +159,11 @@ export const lighthouse: Standard = {
       packageChanges: {
         devDependencies: ['lighthouse'],
         scripts: {
-          'a11y:lighthouse': 'lighthouse http://localhost --output json --output-path ./lighthouse-report.json'
+          'a11y:lighthouse':
+            'lighthouse http://localhost --output json --output-path ./lighthouse-report.json'
         }
       },
-      mainScript: 'a11y:lighthouse',
+      mainScript: 'a11y:lighthouse'
     })
   ]
 };

--- a/src/standards.ts
+++ b/src/standards.ts
@@ -1,4 +1,4 @@
-import { createLintRule, createPrettierRule, Rule } from './rules';
+import { createLintRule, createPrettierRule, Rule, createAccessibilityRule } from './rules';
 
 /** A collection of rules for a language. */
 export interface Standard {
@@ -101,5 +101,68 @@ export const scss: Standard = {
   ]
 };
 
+/** Axe Accessibility Tool */
+export const axe: Standard = {
+  name: 'Axe',
+  keywords: ['axe', 'axe-cli'],
+  description: 'Axe accessibility tool',
+  rules: [
+    createAccessibilityRule({
+      name: 'Axe',
+      description: 'Axe accessibility rule',
+      packageChanges: {
+        devDependencies: ['axe-cli'],
+        scripts: {
+          'a11y:axe': 'axe http://localhost --tags wcag2a,wcag2aa,best-practice --browser chrome',
+        }
+      },
+      mainScript: 'a11y:axe',
+    })
+  ]
+};
+
+/** Pa11y  Accessibility Tool */
+export const pa11y: Standard = {
+  name: 'Pa11y',
+  keywords: ['pa11y'],
+  description: 'Pa11y accessibility tool',
+  rules: [
+    createAccessibilityRule({
+      name: 'Pa11Y',
+      description: 'Pa11y accessibility tool',
+      packageChanges: {
+        devDependencies: ['pa11y'],
+        scripts: {
+          'a11y:pa11y': 'pa11y http://localhost --standard WCAG2AA'
+        }
+      },
+      mainScript: 'a11y:pa11y',
+    })
+  ]
+};
+
+/** Lighthouse  Accessibility Tool */
+export const lighthouse: Standard = {
+  name: 'Lighthouse',
+  keywords: ['lighthouse'],
+  description: 'Lighthouse accessibility tool',
+  rules: [
+    createAccessibilityRule({
+      name: 'Lighthouse',
+      description: 'Lighthouse accessibility tool',
+      packageChanges: {
+        devDependencies: ['lighthouse'],
+        scripts: {
+          'a11y:lighthouse': 'lighthouse http://localhost --output json --output-path ./lighthouse-report.json'
+        }
+      },
+      mainScript: 'a11y:lighthouse',
+    })
+  ]
+};
+
 /** Supported standards */
 export const standards: Standard[] = [javaScript, typeScript, scss];
+
+/** Supported accessibility tools */
+export const accessibilities: Standard[] = [axe, pa11y, lighthouse];

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -98,11 +98,9 @@ export function checkConcurrentScript(
   const concurrentScript = pkg.scripts[type];
   if (concurrentScript) {
     standards.forEach(standard => {
-      if (
-        concurrentScript.includes(standard.keywords[0]) &&
-        standard.rules[0].mainScript
-      ) {
-        currentScripts.push(standard.rules[0].mainScript);
+      const [rule] = standard.rules.filter(rule => rule.type === type);
+      if (concurrentScript.includes(standard.keywords[0]) && rule.mainScript) {
+        currentScripts.push(rule.mainScript);
       }
     });
   }

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -1,0 +1,140 @@
+import fs from 'fs-extra';
+import install from 'install-packages';
+import path from 'path';
+import R, { Dictionary } from 'ramda';
+import { PackageChanges, RuleType } from './rules';
+import { Standard } from './standards';
+
+export function getSelectedStandards(standards: Standard[], types: string[]) {
+  return standards.filter(standard =>
+    types
+      // string[] -> boolean[] - whether any keyword of this standard matched the current type
+      .map(type => standard.keywords.reduce((p, c) => p || c === type, false))
+      // boolean[] -> boolean - whether this standard matched any type
+      .reduce((p, c) => p || c, false)
+  );
+}
+
+export async function processStandards(
+  standards: Standard[],
+  writeScripts: (arr: Standard[]) => Promise<void>
+): Promise<void> {
+  await installDependencies(standards);
+  await installDevDependencies(standards);
+  await copyTemplates(standards);
+  await writeScripts(standards);
+}
+
+async function installDependencies(standards: Standard[]): Promise<void> {
+  const dependencies = mergePackageList(standards, 'dependencies');
+  if (dependencies.length) {
+    console.log('> Installing dependencies:', dependencies.join(', '));
+    try {
+      await install({ packages: dependencies });
+    } catch (e) {
+      console.error(e);
+    }
+  } else {
+    console.warn('> No dependencies provided');
+  }
+}
+
+async function installDevDependencies(standards: Standard[]): Promise<void> {
+  const devDependencies = mergePackageList(standards, 'devDependencies');
+  devDependencies.push('concurrently');
+  devDependencies.push('husky');
+  if (devDependencies.length) {
+    console.log('> Installing devDependencies:', devDependencies.join(', '));
+    try {
+      await install({ packages: devDependencies, saveDev: true });
+    } catch (e) {
+      console.error(e);
+    }
+  } else {
+    console.warn('> No devDependencies provided');
+  }
+}
+
+async function copyTemplates(standards: Standard[]): Promise<void> {
+  const templates = mergeTemplates(standards);
+  if (templates.length) {
+    console.log('> Installing templates: ', templates.join(', '));
+    templates.forEach(
+      async template =>
+        await fs.copy(
+          path.join(path.dirname(require.resolve('./gh')), template),
+          process.cwd(),
+          { overwrite: true }
+        )
+    );
+  } else {
+    console.warn('> No templates provided');
+  }
+}
+
+export function getMainScripts(
+  type: RuleType,
+  standards: Standard[]
+): string[] {
+  return R.uniq((R.flatten(
+    standards.map(s =>
+      R.flatten(
+        s.rules
+          .map(r => (r.type === type && r.mainScript ? r.mainScript : ''))
+          .filter(Boolean)
+      )
+    )
+  ) as any) as string[]);
+}
+
+const colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
+
+export function createConcurrentScript(
+  command: string,
+  scripts: string[],
+  killOthersOnFail?: boolean
+): string {
+  const k = killOthersOnFail ? ' --kill-others-on-fail' : '';
+  const n = scripts.join(',');
+  const c = colors.slice(0, scripts.length).join(',');
+  const s = scripts.map(s => `\"${command} run ${s}\"`).join(' ');
+  return `concurrently${k} -n \"${n}\" -c \"${c}\" ${s}`;
+}
+
+export function mergePackageDictionary<
+  K extends keyof Pick<PackageChanges, 'scripts'>
+>(standards: Standard[], field: K): Dictionary<string> {
+  return standards
+    .map(s =>
+      s.rules
+        .map(r => (r.packageChanges ? r.packageChanges[field] : []))
+        .reduce((p, c) => R.merge(p, c))
+    )
+    .reduce((p, c) => R.merge(p, c)) as Dictionary<string>;
+}
+
+function mergePackageList<
+  K extends keyof Pick<PackageChanges, 'dependencies' | 'devDependencies'>
+>(standards: Standard[], field: K): string[] {
+  return R.uniq(
+    standards
+      .map(s =>
+        s.rules
+          .map(r =>
+            r.packageChanges && r.packageChanges[field]
+              ? (r.packageChanges[field] as string[])
+              : []
+          )
+          .reduce((p = [], c = []) => [...p, ...c])
+      )
+      .reduce((p = [], c = []) => [...p, ...c]) || []
+  );
+}
+
+function mergeTemplates(standards: Standard[]): string[] {
+  return (R.uniq(
+    R.flatten(
+      standards.map(s => R.flatten(s.rules.map(r => r.templates || [])))
+    )
+  ) as any) as string[];
+}

--- a/src/utility.ts
+++ b/src/utility.ts
@@ -89,6 +89,26 @@ export function getMainScripts(
 
 const colors = ['red', 'green', 'yellow', 'blue', 'magenta', 'cyan'];
 
+export function checkConcurrentScript(
+  pkg: any,
+  type: RuleType,
+  standards: Standard[]
+) {
+  const currentScripts: string[] = [];
+  const concurrentScript = pkg.scripts[type];
+  if (concurrentScript) {
+    standards.forEach(standard => {
+      if (
+        concurrentScript.includes(standard.keywords[0]) &&
+        standard.rules[0].mainScript
+      ) {
+        currentScripts.push(standard.rules[0].mainScript);
+      }
+    });
+  }
+  return currentScripts;
+}
+
 export function createConcurrentScript(
   command: string,
   scripts: string[],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@babel/code-frame@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0.tgz#06e2ab19bdb535385559aabb5ba59729482800f8"
+  integrity sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==
+  dependencies:
+    "@babel/highlight" "^7.0.0"
+
+"@babel/highlight@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0.tgz#f710c38c8d458e6dd9a201afb637fcb781ce99e4"
+  integrity sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^4.0.0"
+
 "@fimbul/bifrost@^0.17.0":
   version "0.17.0"
   resolved "https://registry.yarnpkg.com/@fimbul/bifrost/-/bifrost-0.17.0.tgz#f0383ba7e40992e3193dc87e2ddfde2ad62a9cf4"
@@ -48,10 +64,6 @@ ansi-regex@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-3.0.0.tgz#ed0317c322064f79466c02966bddb605ab37d998"
 
-ansi-styles@^2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-2.2.1.tgz#b432dd3358b634cf75e1e4664368240533c1ddbe"
-
 ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
@@ -63,14 +75,6 @@ argparse@^1.0.7:
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   dependencies:
     sprintf-js "~1.0.2"
-
-babel-code-frame@^6.22.0:
-  version "6.26.0"
-  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
-  dependencies:
-    chalk "^1.1.3"
-    esutils "^2.0.2"
-    js-tokens "^3.0.2"
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -107,17 +111,7 @@ camelcase@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.0.0.tgz#03295527d58bd3cd4aa75363f35b2e8d97be2f42"
 
-chalk@^1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-1.1.3.tgz#a8115c55e4a702fe4d150abd3872822a7e09fc98"
-  dependencies:
-    ansi-styles "^2.2.1"
-    escape-string-regexp "^1.0.2"
-    has-ansi "^2.0.0"
-    strip-ansi "^3.0.0"
-    supports-color "^2.0.0"
-
-chalk@^2.3.0, chalk@^2.4.1:
+chalk@^2.0.0, chalk@^2.3.0, chalk@^2.4.1:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   dependencies:
@@ -243,7 +237,7 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
+escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -321,12 +315,6 @@ glob@^7.1.1:
 graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.15"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
-
-has-ansi@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-ansi/-/has-ansi-2.0.0.tgz#34f5049ce1ecdf2b0649af3ef24e45ed35416d91"
-  dependencies:
-    ansi-regex "^2.0.0"
 
 has-flag@^2.0.0:
   version "2.0.0"
@@ -432,11 +420,20 @@ joycon@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/joycon/-/joycon-2.1.2.tgz#565739af7d07b844834c799c1630a9ffab75044e"
 
-js-tokens@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
+js-tokens@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
+  integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.7.0, js-yaml@^3.9.0:
+js-yaml@^3.13.0:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
+  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
+js-yaml@^3.9.0:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.12.1.tgz#295c8632a18a23e054cf5c9d3cecafe678167600"
   dependencies:
@@ -504,6 +501,18 @@ minimatch@^3.0.4:
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   dependencies:
     brace-expansion "^1.1.7"
+
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+mkdirp@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
+  integrity sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=
+  dependencies:
+    minimist "0.0.8"
 
 nice-try@^1.0.4:
   version "1.0.5"
@@ -773,10 +782,6 @@ strip-eof@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-eof/-/strip-eof-1.0.0.tgz#bb43ff5598a6eb05d89b59fcd129c983313606bf"
 
-supports-color@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
-
 supports-color@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
@@ -835,32 +840,34 @@ tslint-microsoft-contrib@~5.2.1:
   dependencies:
     tsutils "^2.27.2 <2.29.0"
 
-tslint@^5.12.1:
-  version "5.12.1"
-  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.12.1.tgz#8cec9d454cf8a1de9b0a26d7bdbad6de362e52c1"
+tslint@^5.11.0:
+  version "5.16.0"
+  resolved "https://registry.yarnpkg.com/tslint/-/tslint-5.16.0.tgz#ae61f9c5a98d295b9a4f4553b1b1e831c1984d67"
+  integrity sha512-UxG2yNxJ5pgGwmMzPMYh/CCnCnh0HfPgtlVRDs1ykZklufFBL1ZoTlWFRz2NQjcoEiDoRp+JyT0lhBbbH/obyA==
   dependencies:
-    babel-code-frame "^6.22.0"
+    "@babel/code-frame" "^7.0.0"
     builtin-modules "^1.1.1"
     chalk "^2.3.0"
     commander "^2.12.1"
     diff "^3.2.0"
     glob "^7.1.1"
-    js-yaml "^3.7.0"
+    js-yaml "^3.13.0"
     minimatch "^3.0.4"
+    mkdirp "^0.5.1"
     resolve "^1.3.2"
     semver "^5.3.0"
     tslib "^1.8.0"
-    tsutils "^2.27.2"
-
-tsutils@^2.27.2, tsutils@^2.29.0:
-  version "2.29.0"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
-  dependencies:
-    tslib "^1.8.1"
+    tsutils "^2.29.0"
 
 "tsutils@^2.27.2 <2.29.0":
   version "2.28.0"
   resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.28.0.tgz#6bd71e160828f9d019b6f4e844742228f85169a1"
+  dependencies:
+    tslib "^1.8.1"
+
+tsutils@^2.29.0:
+  version "2.29.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-2.29.0.tgz#32b488501467acbedd4b85498673a0812aca0b99"
   dependencies:
     tslib "^1.8.1"
 


### PR DESCRIPTION
Add accessibility tooling to the gh-cli in an effort to utilize and standardize on a set of accessibility tools

Initial support: [aXe](https://github.com/dequelabs/axe-cli), [pa11y](https://github.com/pa11y/pa11y), and [lighthouse](https://github.com/GoogleChrome/lighthouse#readme)

The necessary npm libraries are installed, a run script for each tool `a11y:<tool_name>` is created, and a run script that executes all installed run scripts concurrently is created